### PR TITLE
fix(install): Hide a host name in zsh status bar

### DIFF
--- a/oh-my-zsh/custom/themes/powerlevel9k/powerlevel9k.zsh-theme
+++ b/oh-my-zsh/custom/themes/powerlevel9k/powerlevel9k.zsh-theme
@@ -614,8 +614,8 @@ prompt_public_ip() {
 # Note that if $DEFAULT_USER is not set, this prompt segment will always print
 set_default POWERLEVEL9K_ALWAYS_SHOW_CONTEXT false
 set_default POWERLEVEL9K_ALWAYS_SHOW_USER false
-set_default POWERLEVEL9K_CONTEXT_TEMPLATE "%n@%m"
-#set_default POWERLEVEL9K_CONTEXT_TEMPLATE "%n"
+#set_default POWERLEVEL9K_CONTEXT_TEMPLATE "%n@%m"
+set_default POWERLEVEL9K_CONTEXT_TEMPLATE "%n"
 prompt_context() {
   local current_state="DEFAULT"
   typeset -AH context_states


### PR DESCRIPTION
Modify powerlevel9k theme by hidding the host name in zsh status bar.